### PR TITLE
Add five internal docs under .cursor/rules with no code or API changes

### DIFF
--- a/.cursor/rules/00-project-workflow-and-bun.mdc
+++ b/.cursor/rules/00-project-workflow-and-bun.mdc
@@ -1,0 +1,44 @@
+---
+alwaysApply: true
+---
+
+# Project workflow and Bun-only policy
+
+This repository is an Astro + Vue site deployed to Cloudflare Workers. Use Bun for all Node-related tasks; do not use
+npm/yarn/pnpm.
+
+## Project structure quick map
+
+- Config: [astro.config.ts](mdc:astro.config.ts), [uno.config.ts](mdc:uno.config.ts),
+  [.prettierrc.yaml](mdc:.prettierrc.yaml)
+- Pages and routing: [src/pages/index.astro](mdc:src/pages/index.astro),
+  [src/pages/[...slug].astro](mdc:src/pages/[...slug].astro),
+  [src/pages/blog/[...path].astro](mdc:src/pages/blog/[...path].astro)
+- Layouts: [src/layouts/BaseLayout.astro](mdc:src/layouts/BaseLayout.astro)
+- Components (Vue islands): [src/components/Header.vue](mdc:src/components/Header.vue),
+  [src/components/ListPosts.vue](mdc:src/components/ListPosts.vue)
+- Content config and data helpers: [src/content/config.ts](mdc:src/content/config.ts),
+  [src/utils/posts.ts](mdc:src/utils/posts.ts), [src/utils/link.ts](mdc:src/utils/link.ts)
+- Styles: [src/styles/prose.css](mdc:src/styles/prose.css), [src/styles/global.css](mdc:src/styles/global.css)
+
+## Bun-only commands
+
+- Install: `bun install`
+- Dev server: `bun dev` (port 1312; see [astro.config.ts](mdc:astro.config.ts))
+- Build:
+  - Preferred: `bunx astro build`
+  - Or if a script exists: `bun run build`
+- Preview (optional): `bunx astro preview`
+
+## Deploy (Cloudflare Workers)
+
+- Build: `bunx astro build`
+- Deploy: `bunx wrangler deploy`
+
+The SSR Worker entry is emitted at `dist/_worker.js/index.js`. Static assets and other adapter outputs are emitted under
+`dist/`.
+
+## Notes
+
+- Output is configured for SSR via Cloudflare adapter in [astro.config.ts](mdc:astro.config.ts).
+- Prefer UNO utility classes per [uno.config.ts](mdc:uno.config.ts).

--- a/.cursor/rules/01-coding-style-and-ts.mdc
+++ b/.cursor/rules/01-coding-style-and-ts.mdc
@@ -1,0 +1,36 @@
+---
+globs: *.ts,*.tsx,*.astro,*.vue
+---
+
+# Coding style and TypeScript conventions
+
+## General
+
+- ESM only. Use `import`/`export`; avoid CommonJS.
+- Match repository formatting and Prettier settings in [.prettierrc.yaml](mdc:.prettierrc.yaml) (e.g.,
+  `printWidth: 120`, `trailingComma: none`, `endOfLine: lf`).
+- Prefer multi-line clarity over dense one-liners.
+- Comments only for non-obvious rationale, invariants, or caveats.
+
+## TypeScript
+
+- Annotate exported/public APIs. Avoid `any` and unsafe casts.
+- Prefer precise/narrow types. Model domain concepts explicitly.
+- No ambient globals. Prefer module-local utilities and explicit imports.
+
+## Control flow and errors
+
+- Prefer guard clauses and early returns to deep nesting.
+- Use try/catch sparingly and handle errors meaningfully; do not swallow.
+- Keep functions short and focused. Extract helpers when complexity grows.
+
+## Naming
+
+- Use descriptive names. Functions as verbs, variables as nouns.
+- Avoid abbreviations. Favor full words that carry intent.
+
+## Astro and Vue specifics
+
+- In `.astro` files, keep top-of-file script minimal and push logic into typed utilities where possible.
+- In `.vue` components, keep island code lean; avoid heavy global state. Co-locate styles with components when
+  appropriate.

--- a/.cursor/rules/02-astro-vue-patterns.mdc
+++ b/.cursor/rules/02-astro-vue-patterns.mdc
@@ -1,0 +1,34 @@
+---
+globs: *.astro,*.vue
+---
+
+# Astro + Vue patterns
+
+## Rendering model
+
+- SSR is enabled via the Cloudflare adapter in [astro.config.ts](mdc:astro.config.ts) (`output: 'server'`).
+- For routes that do not need SSR (e.g., static legal pages), add in that page file:
+
+```ts
+export const prerender = true;
+```
+
+## Composition
+
+- Prefer Astro pages/markdown for content and structure; mount Vue as islands for interactive pieces only.
+- Keep Vue components focused and small. Example references: [src/components/Header.vue](mdc:src/components/Header.vue),
+  [src/components/ListPosts.vue](mdc:src/components/ListPosts.vue).
+- Use utilities for data loading and sorting: [src/utils/posts.ts](mdc:src/utils/posts.ts),
+  [src/utils/link.ts](mdc:src/utils/link.ts).
+
+## Routing
+
+- Index and landing: [src/pages/index.astro](mdc:src/pages/index.astro)
+- Catch-all content routes: [src/pages/[...slug].astro](mdc:src/pages/[...slug].astro),
+  [src/pages/blog/[...path].astro](mdc:src/pages/blog/[...path].astro)
+- Layouts: [src/layouts/BaseLayout.astro](mdc:src/layouts/BaseLayout.astro)
+
+## Styling
+
+- Prefer UnoCSS utilities configured in [uno.config.ts](mdc:uno.config.ts) and existing styles:
+  [src/styles/global.css](mdc:src/styles/global.css), [src/styles/prose.css](mdc:src/styles/prose.css).

--- a/.cursor/rules/03-content-authoring.mdc
+++ b/.cursor/rules/03-content-authoring.mdc
@@ -1,0 +1,37 @@
+---
+globs: src/content/**/*.md,src/content/**/*.mdx
+---
+
+# Content authoring guidelines
+
+## Collections and placement
+
+- Follow the collection schema defined in [src/content/config.ts](mdc:src/content/config.ts).
+- Blog posts live under `src/content/blog/**`. Additional sections may have their own subfolders.
+
+## Frontmatter
+
+Use concise, complete frontmatter per the schema. Typical fields:
+
+```yaml
+---
+title: Your post title
+description: One-sentence summary
+date: 2025-10-07
+tags:
+  - tag-one
+  - tag-two
+draft: false
+---
+```
+
+## Media and links
+
+- Store images in `public/images/` and reference them with relative paths (they will be served statically).
+- External links open according to site logic; use helpers like [src/utils/link.ts](mdc:src/utils/link.ts) when
+  relevant.
+
+## Slugs and routing
+
+- Filenames typically define slugs and are resolved by dynamic routes such as
+  [src/pages/[...slug].astro](mdc:src/pages/[...slug].astro).

--- a/.cursor/rules/04-cloudflare-workers-deploy.mdc
+++ b/.cursor/rules/04-cloudflare-workers-deploy.mdc
@@ -1,0 +1,55 @@
+---
+alwaysApply: true
+---
+
+# Cloudflare Workers deployment (SSR)
+
+Deploy this Astro site to Cloudflare Workers (not Pages). The Cloudflare adapter is already configured in
+[astro.config.ts](mdc:astro.config.ts) with `output: 'server'`.
+
+## Commands (Bun)
+
+- Build: `bunx astro build`
+- Deploy: `bunx wrangler deploy`
+
+## Wrangler configuration (example: `wrangler.jsonc`)
+
+Place at the repository root if not already present. Adjust `name` as needed.
+
+```jsonc
+{
+  "name": "florentin-dev",
+  "main": "./dist/_worker.js/index.js",
+  "compatibility_date": "2025-03-07",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "./dist"
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  }
+}
+```
+
+## Asset upload exclusions
+
+Add `public/.assetsignore` with:
+
+```
+_worker.js
+_routes.json
+```
+
+## Prerendering guidance
+
+- SSR is default. For routes that do not need SSR, add in that page file:
+
+```ts
+export const prerender = true;
+```
+
+## Reference
+
+- Cloudflare Workers + Astro guide: https://developers.cloudflare.com/workers/framework-guides/web-apps/astro/


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added project workflow guide, including Bun-only commands for install/dev/build/preview and deployment overview.
  * Introduced coding style and TypeScript conventions: ESM usage, naming, control flow, error handling, and Astro/Vue file guidelines.
  * Documented Astro + Vue patterns for rendering, composition, routing, and styling with UnoCSS.
  * Added content authoring guidelines for Markdown/MDX: frontmatter, media handling, links, slugs, and routing.
  * Provided Cloudflare Workers deployment guide for SSR, including configuration tips and prerendering guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->